### PR TITLE
(maint) Fix parent directory generation for subdirectories

### DIFF
--- a/generate_directory_indexes.py
+++ b/generate_directory_indexes.py
@@ -81,10 +81,10 @@ def render_index(prefix, order_by, contents, reverse_order, base_path):
     formatted_contents = format_file_details(sorted_contents)
 
     # If the base path has a '/' in it, assume we're working with a
-    # nested directory and update the base_path so parent directory
-    # works
+    # nested directory and update the base_path so we're only stripping
+    # out the top directory
     if bool('/' in base_path):
-        base_path = '/'.join(base_path.split('/')[:-1])
+        base_path = base_path.split('/')[0]
 
     # Remove the base path from the prefix to avoid putting the full
     # filesystem path in the index

--- a/generate_directory_indexes.py
+++ b/generate_directory_indexes.py
@@ -80,9 +80,14 @@ def render_index(prefix, order_by, contents, reverse_order, base_path):
     sorted_contents = sorted(contents, key=lambda k: k[order_by], reverse=reverse_order)
     formatted_contents = format_file_details(sorted_contents)
 
+    # If the base path has a '/' in it, assume we're working with a
+    # nested directory and update the base_path so parent directory
+    # works
+    if bool('/' in base_path):
+        base_path = '/'.join(base_path.split('/')[:-1])
+
     # Remove the base path from the prefix to avoid putting the full
     # filesystem path in the index
-
     path = '' if prefix == base_path else prefix.replace(base_path, '')
     parent_directory = '/'.join(path.split('/')[:-1])
 


### PR DESCRIPTION
When generating indices for a subset of the release-archives site (apt),
I noticed the 'Parent Directory' for nested directories wasn't working
quite as expected. For example, with
'http://release-archives.puppet.com/apt/dists/' the Parent Directory
shows up as 'http://release-archives.puppet.com/index_by_name.html'.

When kicking off the job both the prefix and the base_path were
'release-archives.puppet.com/apt'. Since this is a nested directory,
when stripping the base_path from the prefix, we only want to remove the
base_path up to the first '/'.