### PR TITLE
Change configuration.verbose check so that it copes with None

### DIFF
--- a/generate_directory_indexes.py
+++ b/generate_directory_indexes.py
@@ -63,14 +63,15 @@ def parse_arguments():
     logger = logging.getLogger(__name__)
     logger_format = '%(filename)s: %(levelname)s %(message)s'
 
-    if configuration.verbose == 1:
+    if configuration.verbose == None:
+        logging.basicConfig(level=logging.ERROR, format=logger_format)
+    elif configuration.verbose == 1:
         logging.basicConfig(level=logging.WARNING, format=logger_format)
     elif configuration.verbose == 2:
         logging.basicConfig(level=logging.INFO, format=logger_format)
-    elif configuration.verbose > 2:
-        logging.basicConfig(level=logging.DEBUG, format=logger_format)
     else:
-        logging.basicConfig(level=logging.ERROR, format=logger_format)
+        logging.basicConfig(level=logging.DEBUG, format=logger_format)
+
 
     if configuration.base_path is None:
         configuration.base_path = configuration.path


### PR DESCRIPTION
I found that the command fails if the --verbose switch is absent because line 70 would try a numeric comparison on None.